### PR TITLE
Add Link - Terraform Provider Keycloak 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 * [terraform-provider-pingdom](https://github.com/russellcardullo/terraform-provider-pingdom) - Terraform provider to manage pingdom resources.
 * [terraform-provider-uptimerobot](https://github.com/louy/terraform-provider-uptimerobot) - Terraform provider to manage uptimerobot resources.
 * [terraform-provider-healthchecksio](https://github.com/kristofferahl/terraform-provider-healthchecksio) - Terraform provider to manage healthchecks.io resources.
+* [terraform-provider-keycloak](https://github.com/mrparkers/terraform-provider-keycloak) - Terraform provider to manage the settings of your [Keycloak](https://www.keycloak.org/) identity provider server.
 
 
 ## Testing


### PR DESCRIPTION
Link to new Terraform Provider for Keycloak