### PR TITLE
Add terraform-bundle to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 * [terraboot](https://github.com/MastodonC/terraboot) - DSL to generate a terraform configuration and run it.
 * [terrafile](https://github.com/coretech/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Go).
 * [terrafile](https://github.com/dxw/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Ruby).
+* [terraform-bundle](https://github.com/hashicorp/terraform/tree/master/tools/terraform-bundle) - A tool to easily build bundles containing a Terraform binary as well as provider binaries. Useful for CI and air-gapped Terraform Enterprise.
 * [terraform-docs](https://github.com/segmentio/terraform-docs) - Quick utility to generate docs from terraform modules.
 * [terraform-landscape](https://github.com/coinbase/terraform-landscape) - Improve Terraform's plan output to be easier to read and understand.
 * [terraform-plan-parser](https://github.com/lifeomic/terraform-plan-parser) - Command line utility and JavaScript API for parsing stdout from `terraform plan` and converting it to JSON.


### PR DESCRIPTION
`terraform-bundle` is super helpful when building Docker images for CI runs. It's not very well publicized so I figured I would add it here.