### PR TITLE
Add `xterrafile` tool and `terraform-digitalocean-droplet` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 * [terraform-azurerm-mysql](https://github.com/foreverXZC/terraform-azurerm-mysql) - Create MySql Database on Azure.
 * [terraform-azurerm-sqlserver](https://github.com/metadevpro/terraform-azurerm-sqlserver-seed) - Create SQl Server Database on Azure.
 * [terraform-azurerm-iis](https://github.com/ghostinthewires/terraform-azurerm-iis-install) - Install IIS Server on Azure VM instance.
+* [terraform-digitalocean-droplet](https://registry.terraform.io/modules/terraform-digitalocean-modules/droplet/digitalocean) - Terraform module for managing DigitalOcean Droplets and related resources.
 * [terraform-linode-k8s](https://registry.terraform.io/modules/linode/k8s/linode/) - Installs Kubernetes on Linode Instances
 
 ## Private Module Registries
@@ -193,6 +194,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 * [tfschema](https://github.com/minamijoyo/tfschema) - Schema inspector for Terraform providers.
 * [tfwrapper](https://github.com/manheim/tfwrapper) - Rubygem providing rake tasks for running Hashicorp Terraform sanely
 * [tgf](https://github.com/coveo/tgf) - Terragrunt frontend for executing Terragrunt/Terraform through Docker.
+* [xterrafile](https://github.com/devopsmakers/xterrafile) Systematically manage external modules from the module registry, git or local directories for use in Terraform (written in Go).
 
 ## Libraries
 


### PR DESCRIPTION
This PR adds the `xterrafile` tool which can help manage Terraform modules in different way with concurrent downloads of modules and the `terraform-digitalocean-droplet` module which manages all the resources that are related to Droplet management and implementation. 