### PR TITLE
Add para to the list of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 * [k2tf](https://github.com/sl1pm4t/k2tf) - Kubernetes YAML to Terraform HCL converter.
 * [json2hcl](https://github.com/kvz/json2hcl) - Convert JSON to HCL and vice versa.
 * [modules.tf](https://modules.tf/) - Infrastructure as code generator - from visual diagrams created with [Cloudcraft.co](https://cloudcraft.co/app) to Terraform. [Source code](https://github.com/antonbabenko/modules.tf-lambda).
+* [para](https://github.com/paraterraform/para) - The missing 3rd-party plugin manager and a "swiss army knife" for Terraform/Terragrunt - just 1 tool to facilitate all workflows.
 * [pre-commit-terraform](https://github.com/antonbabenko/pre-commit-terraform) - pre-commit git hooks to take care of Terraform configurations (auto-format, validate, update docs).
 * [python-terrafile](https://github.com/claranet/python-terrafile) - Systematically manage external modules from Github for use in Terraform.
 * [ruby-terraform](https://github.com/infrablocks/ruby_terraform) - Simple Ruby wrapper for invoking terraform commands.


### PR DESCRIPTION
Hi there, I'd like to add [para](https://github.com/paraterraform/para), my OSS project, to the list of tools.

Para can automatically download 3rd-party plugins and even Terraform and Terragrunt themselves.