### PR TITLE
Add tfupdate to Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 * [tfmask](https://github.com/cloudposse/tfmask) - Terraform utility to mask select output from `terraform plan` and `terraform apply`
 * [tfscaffold](https://github.com/tfutils/tfscaffold) - Framework for controlling multi-environment multi-component terraform-managed AWS infrastructure.
 * [tfschema](https://github.com/minamijoyo/tfschema) - Schema inspector for Terraform providers.
+* [tfupdate](https://github.com/minamijoyo/tfupdate) - Update version constraints in your Terraform configurations.
 * [tfwrapper](https://github.com/manheim/tfwrapper) - Rubygem providing rake tasks for running Hashicorp Terraform sanely.
 * [tgf](https://github.com/coveo/tgf) - Terragrunt frontend for executing Terragrunt/Terraform through Docker.
 * [xterrafile](https://github.com/devopsmakers/xterrafile) Systematically manage external modules from the module registry, git or local directories for use in Terraform (written in Go).


### PR DESCRIPTION
I wrote a small tool which updates version constraints in your Terraform configurations.

https://github.com/minamijoyo/tfupdate

Features:
- Update version constraints of Terraform core and providers
- Update all your Terraform configurations recursively under a given directory
- Get the latest release version automatically from GitHub Release
- Terraform v0.12+ support

I would appreciate it if you could add it to the Tools list.