### PR TITLE
Add Terraform Visual to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 * [tgf](https://github.com/coveo/tgf) - Terragrunt frontend for executing Terragrunt/Terraform through Docker.
 * [xterrafile](https://github.com/devopsmakers/xterrafile) Systematically manage external modules from the module registry, git or local directories for use in Terraform (written in Go).
 * [TerraDepot](https://github.com/derBroBro/TerraDepot) Terraform state repository, based on the default http remote backend. Allows the central administration of tfstates on AWS S3.
+* [Terraform-Visual](https://github.com/hieven/terraform-visual) A simple but powerful tool to visualize Terraform plan
 
 ## Libraries
 


### PR DESCRIPTION
Terraform Visual is a powerful tool I've been working on recently as a side project.

Currently it's able to visualize your Terraform plan and only render changed resources without distracting you with the whole complicated infrastructure hierarchy that you maintain.

The ultimate goal is make it CI/CD friendly so any team using CI/CD can integrate with it easily and benefit from the visualization to spot unwanted infrastructure changes right away

* GitHub: https://github.com/hieven/terraform-visual
* Website: https://hieven.github.io/terraform-visual/