### PR TITLE
Add hcledit to Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [fogg](https://github.com/chanzuckerberg/fogg) - A tool for eliminating toil in managing terraform repositories.
 - [former2](https://github.com/iann0036/former2) - Generate terraform configuration from your existing resources within your AWS account.
 - [geopoiesis](https://docs.geopoiesis.io/manual/) - Specialized continuous integration and deployment tool for modern declarative infrastructure provisioning and management.
+- [hcledit](https://github.com/minamijoyo/hcledit) - A command line editor for HCL.
 - [iam-policy-json-to-terraform](https://github.com/flosell/iam-policy-json-to-terraform) - Small tool to convert an IAM Policy in JSON format into a Terraform aws_iam_policy_document
 - [k2tf](https://github.com/sl1pm4t/k2tf) - Kubernetes YAML to Terraform HCL converter.
 - [json2hcl](https://github.com/kvz/json2hcl) - Convert JSON to HCL and vice versa.


### PR DESCRIPTION
I wrote a command line editor for HCL
https://github.com/minamijoyo/hcledit

Features:

- CLI-friendly: Read HCL from stdin, edit and write to stdout, easily pipe and combine other commands
- Keep comments: You can update lots of existing HCL files with automation scripts
- Schemaless: independent of specific HCL applications
- HCL2 support (not HCL1)

I believe it's useful for Terraform folks.
Thanks!