### PR TITLE
Add tfmigrate to Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [tfjson](https://github.com/palantir/tfjson) - *(outdated)* Utility to read in a Terraform plan file and dump it out in JSON.
 - [tflint](https://github.com/wata727/tflint) - Terraform linter for detecting errors that can not be detected by `terraform plan`
 - [tfmask](https://github.com/cloudposse/tfmask) - Terraform utility to mask select output from `terraform plan` and `terraform apply`
+- [tfmigrate](https://github.com/minamijoyo/tfmigrate) - A Terraform state migration tool for GitOps.
 - [tfscaffold](https://github.com/tfutils/tfscaffold) - Framework for controlling multi-environment multi-component terraform-managed AWS infrastructure.
 - [tfschema](https://github.com/minamijoyo/tfschema) - Schema inspector for Terraform providers.
 - [tfsec](https://github.com/liamg/tfsec) - Static analysis powered security scanner for your terraform code


### PR DESCRIPTION
Hi, I’m author of tfschema, tfupdate, and hcledit.
I’ll share my new project: tfmigrate, which brings you to a new paradigm: Terraform state operation as Code.

Features:
- GitOps friendly: Write terraform state mv/rm/import commands in HCL, plan and apply it.
- Monorepo style support: Move resources to other tfstates to split and merge easily for refactoring.
- Dry run migration: Simulate state operations with a temporary local tfstate and check to see if terraform plan has no changes after the migration without updating remote tfstate.

https://github.com/minamijoyo/tfmigrate