### PR TITLE
Add Terratag

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terrahelp](https://github.com/opencredo/terrahelp) - Command line utility aimed at providing supplementary functionality which can sometimes prove useful when working with Terraform.
 - [terrahub](https://github.com/TerraHubCorp/terrahub) - TerraHub is terraform automation and orchestration tool. Seamlessly integrated into console.terrahub.io, enterprise friendly GUI to show realtime terraform executions, as well as auditing and reporting capabilities for historical terraform runs.
 - [terrascan](https://github.com/cesar-rodriguez/terrascan) - Collection of security and best practice test for static code analysis of terraform templates
+- [terratag](https://github.com/env0/terratag) - Terratag is a CLI tool that enables users of Terraform to automatically create and maintain tags across their entire set of AWS, Azure, and GCP resources  
 - [Checkov](https://github.com/bridgecrewio/checkov/) - Terraform static analysis tool for terraform>=0.12
 - [tfenv](https://github.com/tfutils/tfenv) - Terraform version manager inspired by rbenv.
 - [tfjson](https://github.com/palantir/tfjson) - *(outdated)* Utility to read in a Terraform plan file and dump it out in JSON.


### PR DESCRIPTION
Hey.

I work for [env0](https://www.env0.com/) and am the author of [Terratag](https://github.com/env0/terratag), a CLI tool that enables users of Terraform to automatically create and maintain tags across their entire set of AWS, Azure, and GCP resources.  

Maintaining tags across your application is hard, especially when done manually. Terratag enables you to easily add tags to your existing IaC and benefit from some cross-resource tag applications you wish you had thought of when you had just started writing your Terraform, saving you tons of time and making future updates easy.  

![](https://camo.githubusercontent.com/0ee635546bbd9fc9e5d8fb96481835f676687f6c/68747470733a2f2f6173736574732e776562736974652d66696c65732e636f6d2f3564633366353238353135393562313630626139393637302f3566363230393064326435333263613335653134333133335f74657272617461672e676966)
