### PR TITLE
Add Terraspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terrahelp](https://github.com/opencredo/terrahelp) - Command line utility aimed at providing supplementary functionality which can sometimes prove useful when working with Terraform.
 - [terrahub](https://github.com/TerraHubCorp/terrahub) - TerraHub is terraform automation and orchestration tool. Seamlessly integrated into console.terrahub.io, enterprise friendly GUI to show realtime terraform executions, as well as auditing and reporting capabilities for historical terraform runs.
 - [terrascan](https://github.com/cesar-rodriguez/terrascan) - Collection of security and best practice test for static code analysis of terraform templates
+- [terraspace](https://terraspace.cloud) - The Terraform Framework
 - [Checkov](https://github.com/bridgecrewio/checkov/) - Terraform static analysis tool for terraform>=0.12
 - [tfenv](https://github.com/tfutils/tfenv) - Terraform version manager inspired by rbenv.
 - [tfjson](https://github.com/palantir/tfjson) - *(outdated)* Utility to read in a Terraform plan file and dump it out in JSON.


### PR DESCRIPTION
* Add Terraspace to the tools section
* Terraspace is a Terraform Framework
* Blog Post: [Introducing Terraspace: The Terraform Framework](https://blog.boltops.com/2020/08/22/introducing-terraspace-the-terraform-framework)
* Docs: https://terraspace.cloud/
* Repo: https://github.com/boltops-tools/terraspace
