### PR TITLE
Add one more terraform provider registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [anthology](https://github.com/erikvanbrakel/anthology) - Private Terraform registry implementation as an alternative to the official registry.
 - [citizen](https://github.com/outsideris/citizen) - Private Terraform Module Registry
 - [terraform-simple-registry](https://github.com/apparentlymart/terraform-simple-registry) - Simple implementation of the Terraform registry protocols.
+- [terraform-registry](https://github.com/philips-labs/terraform-registry) - Serve terraform provider registry backed by GitHub releases.
 
 ## Providers
 


### PR DESCRIPTION
This registry https://github.com/philips-labs/terraform-registry allows serving terraform providers published in GitHub releases.