### PR TITLE
docs: replace terraform google groups with terraform discuss

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Sponsored by [Scalr - Terraform Automation & Collaboration Software](https://sca
 - [Terraform Bug Tracker](https://github.com/hashicorp/terraform/issues)
 - [Terraform Community Modules](https://github.com/terraform-community-modules)
 - [Terraform Gitter](https://gitter.im/hashicorp-terraform)
-- [Terraform Google Group](https://groups.google.com/forum/#!forum/terraform-tool)
+- [Terraform Discuss](https://discuss.hashicorp.com/c/terraform-core/27)
 - [Terraform Module Registry](https://registry.terraform.io/)
 - [Terraform PDF Doc](https://github.com/dohsimpson/terraform-doc-pdf) :skull:
 - [Terragrunt Reference Architecture](https://github.com/antonbabenko/terragrunt-reference-architecture)


### PR DESCRIPTION
> Welcome to the HashiCorp Terraform mailing list. As of July 22, 2021 inbound messages to this group have been disabled, and it will now be used for outbound announcements only.
>
> Please direct questions and conversations to our primary medium to communicate with practitioners: HashiCorp Discuss. There you can ask questions, engage with the community, share your stories, and interact with Terraform developers.
>
> For more information about Terraform, please see the website at https://www.terraform.io/.