### PR TITLE
Updates moved `terraform-provider-digitalocean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-provider-buildkite](https://github.com/buildkite/terraform-provider-buildkite) - Plugin for Buildkite.
 - [terraform-provider-checkly](https://github.com/checkly/terraform-provider-checkly) - Manage [Checkly](https://www.checklyhq.com) resources for API & E2E monitoring.
 - [terraform-provider-datadog](https://github.com/DataDog/terraform-provider-datadog) - Plugin for Datadog.
-- [terraform-provider-digitalocean](https://github.com/terraform-providers/terraform-provider-digitalocean) - Plugin for DigitalOcean.
+- [terraform-provider-digitalocean](https://github.com/digitalocean/terraform-provider-digitalocean) - Plugin for DigitalOcean.
 - [terraform-provider-docker](https://github.com/terraform-providers/terraform-provider-docker) - Plugin for Docker.
 - [terraform-provider-dominos](https://github.com/ndmckinley/terraform-provider-dominos) - Provider for Dominos Pizza.
 - [terraform-provider-github](https://github.com/terraform-providers/terraform-provider-github) - Plugin for GitHub.


### PR DESCRIPTION
The DigitalOcean provider was moved to https://github.com/digitalocean/terraform-provider-digitalocean.