### PR TITLE
tools: add validiac

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [tfvaultenv](https://github.com/oulman/tfvaultenv) - tfvaultenv reads secrets from HashiCorp Vault and outputs environment variables for various Terraform providers with those secrets.
 - [tfwrapper](https://github.com/manheim/tfwrapper) - Rubygem providing rake tasks for running Hashicorp Terraform sanely.
 - [tgf](https://github.com/coveo/tgf) - Terragrunt frontend for executing Terragrunt/Terraform through Docker.
+- [validIaC](https://github.com/gofireflyio/validiac) - ValidIaC combines the best open-source tools to help ensure Terraform best practices, hygiene & security.
 - [xterrafile](https://github.com/devopsmakers/xterrafile) Systematically manage external modules from the module registry, git or local directories for use in Terraform (written in Go).
 - [yor](https://github.com/bridgecrewio/yor) - Automatically tag and trace infrastructure as code frameworks (Terraform, Cloudformation and Serverless) .
 


### PR DESCRIPTION
ValidIaC is a new open-source tool that combines several open-source projects and tools to allow developers to check their Terraform HCL (stay tuned for more IaC tools in the near future) code without changing context and from within the same workflow. ValidIaC integrates four popular tools for Terraform to bring the combined value of each tool:

Lint -  tflint, A Pluggable Terraform Linter that finds possible errors (like illegal instance types) and warns about deprecated syntax and unused declarations
Security -  tfsec uses static analysis of your Terraform templates to spot potential security issues.
Cost -  infracost, shows cloud cost estimates for Terraform, before making changes to the cloud.
Mapping -  inframap reads your tfstate or HCL to generate a graph specific for each provider, showing only the resources that are most important/relevant.

ValidIaC makes it possible to leverage the power of four tools in a single place, at any time,  directly from your browser to provide DevOps, SRE, and Cloud teams with peace of mind when deploying and managing Terraform blueprints.