### PR TITLE
Add tpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [tfvaultenv](https://github.com/oulman/tfvaultenv) - tfvaultenv reads secrets from HashiCorp Vault and outputs environment variables for various Terraform providers with those secrets.
 - [tfwrapper](https://github.com/manheim/tfwrapper) - Rubygem providing rake tasks for running Hashicorp Terraform sanely.
 - [tgf](https://github.com/coveo/tgf) - Terragrunt frontend for executing Terragrunt/Terraform through Docker.
+- [tpm](https://github.com/Madh93/tpm) - A package manager for Terraform providers.
 - [validIaC](https://github.com/gofireflyio/validiac) - ValidIaC combines the best open-source tools to help ensure Terraform best practices, hygiene & security.
 - [xterrafile](https://github.com/devopsmakers/xterrafile) Systematically manage external modules from the module registry, git or local directories for use in Terraform (written in Go).
 - [yor](https://github.com/bridgecrewio/yor) - Automatically tag and trace infrastructure as code frameworks (Terraform, Cloudformation and Serverless) .


### PR DESCRIPTION
https://github.com/Madh93/tpm

`tpm`  is a "package manager" (like npm, gem, pip, etc.) but for installing  and uninstalling Terraform providers without requiring Terraform.

I  needed a way to cache a large number of Terraform providers without the  need to clone code repositories and run "terraform init" for each  project on the golden image of our CI system. Caching Terraform providers prevents errors when many Terraform commands run in parallel  and need to download the same provider (related issue: https://github.com/runatlantis/atlantis/issues/2242).


