### PR TITLE
Add terravision tool to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-rake-tasks](https://github.com/gina-alaska/terraform-rake-tasks) - Shared Rake tasks for managing terraform plans.
 - [terraform-repl](https://github.com/paololazzari/terraform-repl) - A terraform console wrapper for a better interactive console experience.
 - [Terraform-Visual](https://github.com/hieven/terraform-visual) - A simple but powerful tool to visualize Terraform plan.
+- [terravision](https://github.com/patrickchugh/terravision) - Generates professional cloud architecture diagrams from Terraform code using official AWS/Azure/GCP icons and design standards. Runs 100% client-side with CI/CD integration.
 - [terraform.py](https://github.com/mantl/terraform.py) - Ansible dynamic inventory script for parsing Terraform state files. :skull:
 - [terraformer](https://github.com/GoogleCloudPlatform/terraformer) - CLI tool to generate terraform files from existing infrastructure. Infrastructure to Code. Supported many providers.
 - [terraforming](https://github.com/dtan4/terraforming) - Export existing AWS resources to Terraform style (tf, tfstate). Similar to `terraformer`. :skull:


### PR DESCRIPTION
Terravision is an open-source CLI tool that automatically generates  solution architect grade cloud architecture diagrams from Terraform  code using official AWS, Azure, and GCP icons and design standards.

- 1,400+ GitHub stars
- Supports AWS, Azure, and GCP
- Runs 100% client-side (no cloud dependencies)
- CI/CD integration via GitHub Actions
- Exports to draw.io, SVG, PNG, PDF and all Graphviz formats
- YAML-based annotation system for custom labels

https://github.com/patrickchugh/terravision