### PR TITLE
Add Qovery Terraform provider to vendor supported providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-provider-panos](https://github.com/PaloAltoNetworks/terraform-provider-panos) - Provider for [Palo Alto Networks next-generation firewalls](https://www.paloaltonetworks.com/network-security).
 - [terraform-provider-phare](https://github.com/phare/terraform-provider-phare) -  Terraform provider for [Phare](https://phare.io).
 - [terraform-provider-planetscale](https://github.com/planetscale/terraform-provider-planetscale) -  Terraform provider for [PlanetScale](https://planetscale.com) (Vitess & Postgres).
+- [terraform-provider-qovery](https://github.com/Qovery/terraform-provider-qovery) - Provider for [Qovery](https://www.qovery.com/) — manage Kubernetes deployments, environments, applications, databases, Helm charts, and Terraform services on AWS, GCP, Azure, and Scaleway.
 - [terraform-provider-pingdom](https://github.com/russellcardullo/terraform-provider-pingdom) - Provider to manage Pingdom resources. :skull:
 - [terraform-provider-rancher2](https://github.com/rancher/terraform-provider-rancher2) - Provider for Rancher v2.
 - [terraform-provider-scalr](https://github.com/Scalr/terraform-provider-scalr) - Provider for [Scalr](https://www.scalr.com/)


### PR DESCRIPTION
Adds the [Qovery Terraform provider](https://github.com/Qovery/terraform-provider-qovery) to the vendor supported providers section.

The Qovery Terraform provider allows managing Kubernetes deployments as infrastructure as code, including:
- Environments, applications, containers, databases
- Helm charts, Terraform services, lifecycle jobs, cron jobs
- Deployment stages, environment variables (with aliases, interpolation, overrides)
- Clusters and cloud credentials (AWS, GCP, Azure, Scaleway)

Terraform Registry: https://registry.terraform.io/providers/Qovery/qovery/latest/docs
Provider source code: https://github.com/Qovery/terraform-provider-qovery
Real-world example: https://github.com/evoxmusic/Doktolib/blob/main/qovery.tf
Website: https://www.qovery.com