### PR TITLE
how-to: Add AWS Account Vending Machine tutorial to How-To section

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Terraform enables you to safely and predictably create, change, and improve prod
 - [Google Cloud Platform for 10$ a month using terraform](https://github.com/nufailtd/terraform-budget-gcp) - Shows how to use terraform to create a secure Google Kubernetes Cluster, Google Cloud Run Services and other infrastructure elements for less than [10$](https://nufailtd.github.io/budget-gcp/) a month.
 - [Infracost + Terraform + GitHub Actions = Automate Cloud Cost Management](https://medium.com/better-programming/infracost-terraform-github-actions-automate-cloud-cost-management-a62b329f2834) - How to use Infracost as the guardrail to manage cloud cost during Terraform development.
 - [How To Wrap Your Terraform Provider for Pulumi](https://www.speakeasyapi.dev/post/pulumi-terraform-provider) - Making your terraform provider pulumi-ready
+- [How to Build an AWS Account Vending Machine](https://medium.com/@StackGuardian/how-to-build-an-aws-account-vending-machine-by-stackguardian-f2895e35a27b) - Automated, self-service AWS account lifecycle management using Terraform stacks orchestrated by StackGuardian, with SSM-based allocation, EventBridge cleanup triggers, and Tirith policy enforcement.
 
 ### Multi-Environment Configuration
 


### PR DESCRIPTION
Adding a how-to tutorial to the "How-To" section under Tutorials and Blog Posts.

## What's being added

- [How to Build an AWS Account Vending Machine](https://medium.com/@StackGuardian/how-to-build-an-aws-account-vending-machine-by-stackguardian-f2895e35a27b) - Automated, self-service AWS account lifecycle management using Terraform stacks orchestrated by StackGuardian, with SSM-based allocation, EventBridge cleanup triggers, and Tirith policy enforcement.

## Why it fits

A practical, code-heavy tutorial covering Terraform stack orchestration, SSM-based account allocation, EventBridge cleanup triggers, and policy enforcement with Tirith and OPA — consistent with the other how-to entries in this section.