### PR TITLE
Add tf-why: Terraform drift attribution via CloudTrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [tf-init-booster](https://github.com/hayorov/terraform-init-booster) - A Pre-terraform routine that speedups terraform modules download for bulky blueprints.
 - [tf-profile](https://github.com/datarootsio/tf-profile/) - Profiler for Terraform runs. Generate global stats, resource-level stats or visualizations.
 - [tf-summarize](https://github.com/dineshba/tf-summarize) - A command-line utility to print the summary of the terraform plan
+- [tf-why](https://github.com/Raj-glitch-max/tf.why) - CLI tool that attributes Terraform drift to the AWS actor who caused it, via CloudTrail lookup.
 - [tfaction](https://github.com/suzuki-shunsuke/tfaction) - GitHub Actions collection for Opinionated Terraform Workflow
 - [tfautomv](https://github.com/busser/tfautomv) - Generate Terraform `moved` blocks automatically for painless refactoring
 - [tfcmt](https://github.com/suzuki-shunsuke/tfcmt) - CLI to notify the result of plan and apply as Pull Request comment.


### PR DESCRIPTION
Hi! I'm nominating tf-why, a CLI tool that helps platform engineers identify who caused infrastructure drift.

Terraform tells you what drifted, but finding the root cause usually involves hunting through CloudTrail logs. tf-why automates this by correlating Terraform plan JSON with CloudTrail events to attribute the change to a specific AWS actor, timestamp, and API event.

Key features:

Correlates terraform plan output with CloudTrail.
Attributes changes to specific IAM Users, Roles, or SSO identities.
Non-invasive (read-only access).
JSON and Plain text output for CI/CD integration.
Repo: https://github.com/Raj-glitch-max/tf.why