### PR TITLE
Add terraform-stack to Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 
 ## Boilerplates
 
+- [Solo-Engineer Stack](https://github.com/sarmakska/terraform-stack) - Single Terraform repo wiring up Vercel + Supabase + Cloudflare + DigitalOcean as the indie-SaaS platform. One `terraform apply` provisions a Next.js project, a Supabase project with env vars piped to Vercel, a Cloudflare zone with R2 and Workers KV, and a DigitalOcean droplet with monitoring.
 - [Terraform Generator](https://github.com/sudokar/generator-tf-module) - Scaffolding for a new terraform module or project with support of test frameworks (terratest and kitchen-terraform)
 - [Terraform GitOps Framework](https://www.kubestack.com) - Everything you need to build reliable automation for AKS, EKS, and GKE Kubernetes clusters in one free and open-source framework.
 


### PR DESCRIPTION
Adds [terraform-stack](https://github.com/sarmakska/terraform-stack) under Boilerplates. It is a single Terraform repo that provisions the four services most solo engineers actually use together — Vercel, Supabase, Cloudflare, DigitalOcean — wired up correctly in one `terraform apply`. Includes Vercel project linked to GitHub, Supabase project with env vars piped to Vercel, Cloudflare zone with R2 + Workers KV, and a DigitalOcean droplet with monitoring.

MIT licensed, public repo, README has architecture diagram and quick-start.

Project page: https://sarmalinux.com/products/terraform-stack