### PR TITLE
fix: remove Styra DAS entry (404 + invalid SSL cert)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,6 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [Shisho](https://github.com/flatt-security/shisho) - Lightweight static analyzer for Terraform.
 - [Speakeasy](https://www.speakeasyapi.dev/) - Generate a terraform provider from an OpenAPI specification.
 - [stacks](https://github.com/cisco-open/stacks) - Stacks, the Terraform code pre-processor
-- [Styra Declarative Authorization Service (DAS)](https://www.styra.com/terraform-cloud-config-management-with-styra-das-and-open-policy-agent) - Provides a managed [Open Policy Agent (OPA)](https://www.openpolicyagent.org) platform for Application and Infrastructure use cases, including Terraform, Terraform Cloud, and Kubernetes. Enforce policy guardrails during development, in CI/CD pipelines, and at deploy time. Styra DAS Free provides multiple systems and users, policy impact analysis, decision logging and replay, and access to Styra's Terraform policy library.
 - [tads-boilerplate](https://github.com/Thomvaill/tads-boilerplate) - The power of Ansible and Terraform + the simplicity of Docker Swarm = Infrastructure as Code and DevOps best practices.
 - [tau](https://github.com/avinor/tau) - Tau is a thin wrapper on top of terraform to manage multiple deployments, dependencies, and secrets. :skull:
 - [tenv](https://github.com/tofuutils/tenv) - OpenTofu/Terraform/Terragrunt version manager.


### PR DESCRIPTION
The Styra DAS link is broken in two ways:

- **SSL cert mismatch**: `www.styra.com` currently serves a Pantheon CDN cert valid only for `*.pantheon.io` — not `styra.com`. Lychee reports: `SSL certificate error. Check certificate validity`
- **404**: Page returns 404 (ignoring SSL). No redirect to a new location.
- **No archive**: Wayback Machine has no snapshot of this URL.

Removing the entry entirely.