### PR TITLE
fix: CI workflow bugs and lychee config improvements

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git diff --unified=0 --diff-filter=ACMRT HEAD^1 HEAD -- README.md > readme.diff
+          git diff --unified=0 --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} HEAD -- README.md > readme.diff
           awk '/^\+[^+]/ { sub(/^\+/, ""); print }' readme.diff \
             | grep -Eo 'https?://[^][) <>"]+' \
             | sed -E 's/[),.;:!?]+$//' \

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -4,8 +4,15 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '**.md'
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**.md'
+
+permissions:
+  contents: read
 
 jobs:
   misspell:

--- a/.github/workflows/notfound.yml
+++ b/.github/workflows/notfound.yml
@@ -2,6 +2,8 @@ name: notfoundbot
 
 on:
   push:
+    branches:
+      - master
   schedule:
     - cron: "12 4 * * *"
   workflow_dispatch:

--- a/lychee.toml
+++ b/lychee.toml
@@ -20,7 +20,8 @@ exclude = [
 ]
 
 # Alternative: Exclude hashicorp.com if rate limiting persists
-# Uncomment the line below if you want to skip hashicorp.com checks entirely
+# WARNING: uncommenting the line below REPLACES the entire exclude array above,
+# not adds to it. Add hashicorp.com as an additional entry in the array instead.
 # exclude = ['https://www\.hashicorp\.com/.*']
 
 # Cache results to avoid repeated checks


### PR DESCRIPTION
Four improvements found during repo audit.

## notfound.yml — push trigger fires on every branch
```yaml
on:
  push:        # ← no branch filter
```
This workflow has `contents: write` and `pull-requests: write` permissions. Running on every push to any branch (including feature branches, Dependabot bumps) means the bot could open fix PRs from unreviewed branches. Added `branches: [master]` to restrict to master-only.

## link-checker.yml — PR diff misses earlier commits
```bash
git diff ... HEAD^1 HEAD   # ← only last commit in the PR
```
For multi-commit PRs, `HEAD^1` is the previous commit in the PR branch, not the base branch. Links added in all but the last commit are silently skipped. Fixed to use `${{ github.event.pull_request.base.sha }}` as the base.

## misspell.yml — unnecessary trigger noise
- `types: [assigned, ...]` — reviewer assignment re-runs spellcheck with no file changes. Removed `assigned`.
- No `paths` filter — ran on every push even when only non-text files changed. Added `paths: ['**.md']`.
- No `permissions` block — added `contents: read` for least-privilege.

## lychee.toml — misleading comment
The commented-out `exclude = ['...']` line would **replace** the entire `exclude` array if uncommented (TOML array assignment), not add to it. Added a warning so future maintainers don't accidentally drop all existing exclusions.