### PR TITLE
Add Azure Verified Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-aws-transit-gateway](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway) - Creates Transit Gateway resources on AWS.
 - [terraform-aws-vpc](https://github.com/terraform-aws-modules/terraform-aws-vpc) - Creates VPC resources on AWS (verified and very popular module).
 - [terraform-aws-vpn-gateway](https://github.com/terraform-aws-modules/terraform-aws-vpn-gateway) - Creates VPN gateway resources on AWS.
+- [Azure Verified Modules](https://azure.github.io/Azure-Verified-Modules/) - Official Microsoft-owned collection of verified Terraform modules for Azure, codifying WAF best practices for consistent infrastructure deployment.
 - [terraform-azurerm-aks](https://github.com/kjanshair/terraform-azurerm-aks) - Create AKS resources on Azure.
 - [terraform-azurerm-iis](https://github.com/ghostinthewires/terraform-azurerm-iis-install) - Install IIS Server on Azure VM instance.
 - [terraform-azurerm-mysql](https://github.com/foreverXZC/terraform-azurerm-mysql) - Create MySql Database on Azure.
@@ -256,6 +257,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 
 ## Managed Registries
 
+- [Azure Verified Modules](https://azure.github.io/Azure-Verified-Modules/) - Official Microsoft initiative providing verified, standards-compliant Terraform (and Bicep) modules for Azure resources and architectural patterns, aligned with the Well-Architected Framework.
 - [cloudsmith](https://docs.cloudsmith.com/formats/terraform-modules-repository) - Managed package hoster for internal and external clients. :heavy_dollar_sign:
 
 ## Providers


### PR DESCRIPTION
## Summary

- Adds [Azure Verified Modules (AVM)](https://azure.github.io/Azure-Verified-Modules/) to the **Managed Registries** section — the primary placement, as AVM is Microsoft's official, verified module registry initiative for Azure.
- Also adds AVM to the **Community Modules → Azure** subsection alongside existing `terraform-azurerm-*` modules.

AVM is an official Microsoft-driven initiative that consolidates and sets standards for Infrastructure-as-Code modules (Terraform and Bicep), aligned with the Azure Well-Architected Framework.