### PR TITLE
remove: drop unmaintained tfe-state-explorer entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,6 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-enterprise-cli](https://github.com/skierkowski/terraform-enterprise-cli) - Terraform Enterprise Command Line Interface.
 - [terraform-enterprise-client](https://github.com/skierkowski/terraform-enterprise-client) - Terraform Enterprise API Ruby Client and Command Line tool.
 - [terraform-enterprise-migrator](https://github.com/sil-org/tfc-ops) - Script for migrating Terraform Enterprise environments from Legacy to new version of Terraform Enterprise.
-- [tfe-state-explorer](https://github.com/segment-boneyard/tfe-state-explorer) - Simple shell for exploring remote terraform enterprise state, with autocomplete. :skull:
 
 ## Videos
 


### PR DESCRIPTION
## Summary

Removes the `tfe-state-explorer` entry from the **Terraform Enterprise Tooling** section.

## Reasons for removal

- **Targets a dead API.** The tool hardcodes `https://atlas.hashicorp.com` — HashiCorp Atlas was retired in 2017 and replaced by Terraform Cloud/Enterprise. The legacy Atlas v1 API it relies on no longer exists.
- **Severely outdated dependencies.** Uses the legacy `govendor` toolchain (pre-Go modules). All dependencies are pinned to 2016–2018 revisions; no `go.mod` or `go.sum` files exist.
- **Functionality fully superseded.** Everything this tool provided is now available natively via `terraform state list`, `terraform state show`, `terraform output`, the Terraform Cloud/Enterprise web UI, and the current TFC/TFE REST API v2.
- **Officially abandoned.** The project was moved to the `segment-boneyard` org and its own README explicitly states it is *no longer maintained nor supported*. The entry already carried a `:skull:` marker in this list.

## References

- Repository: https://github.com/segment-boneyard/tfe-state-explorer

Co-authored-by: OpenCode <opencode@anomaly.co>
Co-authored-by: Claude <claude@anthropic.com>