### PR TITLE
Add deploydiff to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,6 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [coretech/terrafile](https://github.com/coretech/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Go). :skull:
 - [deploydiff](https://github.com/Coding-Dev-Tools/deploydiff) - Preview Terraform plan diffs with cost impact estimation and rollback commands before deploying.
 - [driftctl](https://github.com/snyk/driftctl) - Detect, track, and alert on infrastructure drift :skull:
-- [deploydiff](https://github.com/Coding-Dev-Tools/deploydiff) - Preview infrastructure changes with human-readable diffs, cost impact estimation, and rollback commands — before you hit deploy.
 - [drifthound](https://github.com/drifthoundhq/drifthound) - Continuous infrastructure drift detection with historical tracking and notifications.
 - [dxw/terrafile](https://github.com/dxw/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Ruby).
 - [flora](https://github.com/ketchoop/flora) - Terraform version manager.

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - AWS security auditing CLI with remediation engine that generates Terraform code for fixing misconfigurations.
 - [Coder](https://coder.com/) - Coder provisions software development environments on your infrastructure via Terraform.
 - [coretech/terrafile](https://github.com/coretech/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Go). :skull:
+- [deploydiff](https://github.com/Coding-Dev-Tools/deploydiff) - Preview Terraform plan diffs with cost impact estimation and rollback commands before deploying.
 - [driftctl](https://github.com/snyk/driftctl) - Detect, track, and alert on infrastructure drift :skull:
 - [deploydiff](https://github.com/Coding-Dev-Tools/deploydiff) - Preview infrastructure changes with human-readable diffs, cost impact estimation, and rollback commands — before you hit deploy.
 - [drifthound](https://github.com/drifthoundhq/drifthound) - Continuous infrastructure drift detection with historical tracking and notifications.

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [Coder](https://coder.com/) - Coder provisions software development environments on your infrastructure via Terraform.
 - [coretech/terrafile](https://github.com/coretech/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Go). :skull:
 - [driftctl](https://github.com/snyk/driftctl) - Detect, track, and alert on infrastructure drift :skull:
+- [deploydiff](https://github.com/Coding-Dev-Tools/deploydiff) - Preview infrastructure changes with human-readable diffs, cost impact estimation, and rollback commands — before you hit deploy.
 - [drifthound](https://github.com/drifthoundhq/drifthound) - Continuous infrastructure drift detection with historical tracking and notifications.
 - [dxw/terrafile](https://github.com/dxw/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Ruby).
 - [flora](https://github.com/ketchoop/flora) - Terraform version manager.


### PR DESCRIPTION
Adds [deploydiff](https://github.com/coding-dev-tools/deploydiff) to the Tools section alongside Infracost.

deploydiff compares Terraform plans to show infrastructure cost and configuration changes before deployment. It complements Infracost by also showing config diffs, giving teams a complete picture of what will change before applying.

- Active development with CI passing
- npm: https://www.npmjs.com/package/deploydiff