### PR TITLE
Add configdrift to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - AWS security auditing CLI with remediation engine that generates Terraform code for fixing misconfigurations.
 - [Coder](https://coder.com/) - Coder provisions software development environments on your infrastructure via Terraform.
 - [coretech/terrafile](https://github.com/coretech/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Go). :skull:
+- [configdrift](https://github.com/Coding-Dev-Tools/configdrift) - Detect configuration drift across your infrastructure. Monitor and alert on config changes in real-time.
 - [driftctl](https://github.com/snyk/driftctl) - Detect, track, and alert on infrastructure drift :skull:
 - [drifthound](https://github.com/drifthoundhq/drifthound) - Continuous infrastructure drift detection with historical tracking and notifications.
 - [dxw/terrafile](https://github.com/dxw/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Ruby).


### PR DESCRIPTION
Adds [configdrift](https://github.com/coding-dev-tools/configdrift) to the Tools section alongside driftctl and drifthound.

configdrift detects configuration drift across environments for Terraform-managed infrastructure. It complements existing drift detection tools by focusing on configuration-level drift (not just resource-level), helping teams maintain consistency across dev/staging/prod environments.

- Active development with CI passing
- npm: https://www.npmjs.com/package/configdrift