### PR TITLE
tools: Add platform-skills — AI-assisted Terraform review and IAM audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [para](https://github.com/paraterraform/para) - The missing 3rd-party plugin manager and a "Swiss army knife" for Terraform/Terragrunt - just 1 tool to facilitate all workflows. :skull:
 - [pike](https://github.com/jamesWoolfenden/pike) - Pike calculates the permissions or IAM policy required to build your Terraform.
 - [pipeform](https://github.com/magodo/pipeform) - Terraform runtime TUI
+- [platform-skills](https://github.com/nitinjain999/platform-skills) - AI-assisted field handbook for Terraform: IAM least privilege review, blast radius analysis, state impact, provider constraints, and rollback planning. Works as a Claude, Codex, Cursor, and Copilot plugin.
 - [pluralith](https://www.pluralith.com/) - Terraform state visualization and automated generation of infrastructure documentation. :heavy_dollar_sign:
 - [pre-commit-terraform](https://github.com/antonbabenko/pre-commit-terraform) - pre-commit git hooks for Terraform and Terragrunt: auto-format, validate, update docs, run security checks, estimate costs, and more.
 - [pretf](https://github.com/raymondbutcher/pretf) - drop-in Terraform wrapper that generates Terraform configuration with Python. See [pretf documentation](https://pretf.readthedocs.io/en/latest/) :skull:


### PR DESCRIPTION
## Description

Adds [platform-skills](https://github.com/nitinjain999/platform-skills) to the Tools section (alphabetically between pipeform and pluralith).

platform-skills is a free, open-source field handbook for Terraform and platform engineers with patterns for IAM least privilege, blast radius analysis, state impact, provider constraints, and rollback planning. It works as a Claude, Codex, Cursor, and Copilot plugin — giving engineers interactive guidance during plan review.

## Checklist

- [x] Entry is alphabetically placed (between pipeform and pluralith)
- [x] Description is concise and accurate
- [x] Link points to the correct GitHub repo