### PR TITLE
Add Kapitan to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [InfraSketch](https://infrasketch.cloud) - Free browser-based tool to visualize Terraform HCL and Docker Compose as architecture diagrams. Supports AWS & Azure. No signup, no credentials needed.
 - [json2hcl](https://github.com/kvz/json2hcl) - Convert JSON to HCL and vice versa. :ghost:
 - [k2tf](https://github.com/sl1pm4t/k2tf) - Kubernetes YAML to Terraform HCL converter.
+- [Kapitan](https://github.com/kapicorp/kapitan) - Generates Terraform/OpenTofu JSON and other infrastructure configuration from inventory-driven templates.
 - [KICS](https://github.com/Checkmarx/kics) - Scans IaC projects for security vulnerabilities, compliance issues, and infrastructure misconfiguration. Currently working with Terraform projects, Kubernetes manifests, Dockerfiles, AWS CloudFormation Templates, and Ansible playbooks.
 - [layerform](https://github.com/briefercloud/layerform) - Layerform helps engineers create reusable environment stacks using plain .tf files. Ideal for multiple "staging" environments. :skull:
 - [library.tf](https://library.tf) - Library.tf is built and designed to not just provide you with all of the registry information for Terraform and OpenTofu but to provide all of the insights you need to make decisions. Quickly find modules or providers that are supported and maintained and not full of bugs.


### PR DESCRIPTION
Adds Kapitan to the Tools section.

Kapitan generates Terraform/OpenTofu JSON and other infrastructure configuration from inventory-driven templates. It generates the configuration; Terraform or OpenTofu still runs it.

I placed it alphabetically (between k2tf and KICS) and matched the existing line format.

- https://github.com/kapicorp/kapitan
- https://kapitan.dev/latest/pages/kapitan_examples/
